### PR TITLE
Change types of `MaxBatchSize` and `MinInstancesInService` to support legacy eksctl templates

### DIFF
--- a/cloudformation/policies/policies.go
+++ b/cloudformation/policies/policies.go
@@ -81,13 +81,13 @@ type AutoScalingReplacingUpdate struct {
 type AutoScalingRollingUpdate struct {
 
 	// MaxBatchSize specifies the maximum number of instances that AWS CloudFormation updates.
-	MaxBatchSize float64 `json:"MaxBatchSize,omitempty"`
+	MaxBatchSize string `json:"MaxBatchSize,omitempty"`
 
 	// MinInstancesInService specifies the minimum number of instances that must be in service within the Auto Scaling group while AWS CloudFormation updates old instances.
-	MinInstancesInService float64 `json:"MinInstancesInService,omitempty"`
+	MinInstancesInService string `json:"MinInstancesInService,omitempty"`
 
 	// MinSuccessfulInstancesPercent specifies the percentage of instances in an Auto Scaling rolling update that must signal success for an update to succeed. You can specify a value from 0 to 100. AWS CloudFormation rounds to the nearest tenth of a percent. For example, if you update five instances with a minimum successful percentage of 50, three instances must signal success.
-	MinSuccessfulInstancesPercent float64 `json:"MinSuccessfulInstancesPercent,omitempty"`
+	MinSuccessfulInstancesPercent string `json:"MinSuccessfulInstancesPercent,omitempty"`
 
 	// PauseTime is the amount of time that AWS CloudFormation pauses after making a change to a batch of instances to give those instances time to start software applications. For example, you might need to specify PauseTime when scaling up the number of instances in an Auto Scaling group.
 	PauseTime string `json:"PauseTime,omitempty"`

--- a/cloudformation/policies/policies.go
+++ b/cloudformation/policies/policies.go
@@ -1,5 +1,7 @@
 package policies
 
+import "github.com/weaveworks/goformation/v4/cloudformation/types"
+
 // CreationPolicy prevents a resource status from reaching create complete until AWS CloudFormation receives a specified number of success signals or the timeout period is exceeded. To signal a resource, you can use the cfn-signal helper script or SignalResource API. AWS CloudFormation publishes valid signals to the stack events so that you track the number of signals sent.
 type CreationPolicy struct {
 
@@ -81,13 +83,13 @@ type AutoScalingReplacingUpdate struct {
 type AutoScalingRollingUpdate struct {
 
 	// MaxBatchSize specifies the maximum number of instances that AWS CloudFormation updates.
-	MaxBatchSize string `json:"MaxBatchSize,omitempty"`
+	MaxBatchSize types.Value `json:"MaxBatchSize,omitempty"`
 
 	// MinInstancesInService specifies the minimum number of instances that must be in service within the Auto Scaling group while AWS CloudFormation updates old instances.
-	MinInstancesInService string `json:"MinInstancesInService,omitempty"`
+	MinInstancesInService types.Value `json:"MinInstancesInService,omitempty"`
 
 	// MinSuccessfulInstancesPercent specifies the percentage of instances in an Auto Scaling rolling update that must signal success for an update to succeed. You can specify a value from 0 to 100. AWS CloudFormation rounds to the nearest tenth of a percent. For example, if you update five instances with a minimum successful percentage of 50, three instances must signal success.
-	MinSuccessfulInstancesPercent string `json:"MinSuccessfulInstancesPercent,omitempty"`
+	MinSuccessfulInstancesPercent float64 `json:"MinSuccessfulInstancesPercent,omitempty"`
 
 	// PauseTime is the amount of time that AWS CloudFormation pauses after making a change to a batch of instances to give those instances time to start software applications. For example, you might need to specify PauseTime when scaling up the number of instances in an Auto Scaling group.
 	PauseTime string `json:"PauseTime,omitempty"`

--- a/cloudformation/policies_test.go
+++ b/cloudformation/policies_test.go
@@ -37,9 +37,9 @@ var _ = Describe("Goformation", func() {
 				Name: "AutoScalingReplacingUpdate",
 				Input: &policies.UpdatePolicy{
 					AutoScalingRollingUpdate: &policies.AutoScalingRollingUpdate{
-						MaxBatchSize:                  10,
-						MinInstancesInService:         11,
-						MinSuccessfulInstancesPercent: 12,
+						MaxBatchSize:                  "10",
+						MinInstancesInService:         "11",
+						MinSuccessfulInstancesPercent: "12",
 						PauseTime:                     "test-pause-time",
 						SuspendProcesses:              []string{"test-suspend1", "test-suspend2"},
 						WaitOnResourceSignals:         true,
@@ -47,9 +47,9 @@ var _ = Describe("Goformation", func() {
 				},
 				Expected: map[string]interface{}{
 					"AutoScalingRollingUpdate": map[string]interface{}{
-						"MaxBatchSize":                  float64(10),
-						"MinInstancesInService":         float64(11),
-						"MinSuccessfulInstancesPercent": float64(12),
+						"MaxBatchSize":                  "10",
+						"MinInstancesInService":         "11",
+						"MinSuccessfulInstancesPercent": "12",
 						"PauseTime":                     "test-pause-time",
 						"SuspendProcesses":              []interface{}{"test-suspend1", "test-suspend2"},
 						"WaitOnResourceSignals":         true,

--- a/cloudformation/policies_test.go
+++ b/cloudformation/policies_test.go
@@ -2,6 +2,7 @@ package cloudformation_test
 
 import (
 	"github.com/sanathkr/yaml"
+	"github.com/weaveworks/goformation/v4/cloudformation/types"
 
 	"github.com/weaveworks/goformation/v4/cloudformation"
 	"github.com/weaveworks/goformation/v4/cloudformation/autoscaling"
@@ -37,9 +38,9 @@ var _ = Describe("Goformation", func() {
 				Name: "AutoScalingReplacingUpdate",
 				Input: &policies.UpdatePolicy{
 					AutoScalingRollingUpdate: &policies.AutoScalingRollingUpdate{
-						MaxBatchSize:                  "10",
-						MinInstancesInService:         "11",
-						MinSuccessfulInstancesPercent: "12",
+						MaxBatchSize:                  *types.NewInteger(10),
+						MinInstancesInService:         *types.NewInteger(11),
+						MinSuccessfulInstancesPercent: float64(12),
 						PauseTime:                     "test-pause-time",
 						SuspendProcesses:              []string{"test-suspend1", "test-suspend2"},
 						WaitOnResourceSignals:         true,
@@ -47,9 +48,9 @@ var _ = Describe("Goformation", func() {
 				},
 				Expected: map[string]interface{}{
 					"AutoScalingRollingUpdate": map[string]interface{}{
-						"MaxBatchSize":                  "10",
-						"MinInstancesInService":         "11",
-						"MinSuccessfulInstancesPercent": "12",
+						"MaxBatchSize":                  float64(10),
+						"MinInstancesInService":         float64(11),
+						"MinSuccessfulInstancesPercent": float64(12),
 						"PauseTime":                     "test-pause-time",
 						"SuspendProcesses":              []interface{}{"test-suspend1", "test-suspend2"},
 						"WaitOnResourceSignals":         true,


### PR DESCRIPTION
See https://github.com/weaveworks/eksctl/issues/3190