### PR TITLE
Add support for UpdateConfig to EKS Nodegroups

### DIFF
--- a/cloudformation/eks/aws-eks-nodegroup.go
+++ b/cloudformation/eks/aws-eks-nodegroup.go
@@ -94,6 +94,11 @@ type Nodegroup struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-taints
 	Taints []*Nodegroup_Taints `json:"Taints,omitempty"`
 
+	// UpdateConfig AWS CloudFormation Property
+	// Required: false
+	// TODO @nikimanoledaki: Add link to docs
+	UpdateConfig *Nodegroup_UpdateConfig `json:"UpdateConfig,omitempty"`
+
 	// Version AWS CloudFormation Property
 	// Required: false
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-nodegroup.html#cfn-eks-nodegroup-version

--- a/cloudformation/eks/aws-eks-nodegroup_updateconfig.go
+++ b/cloudformation/eks/aws-eks-nodegroup_updateconfig.go
@@ -1,0 +1,18 @@
+package eks
+
+import "github.com/weaveworks/goformation/v4/cloudformation/types"
+
+// Nodegroup_UpdateConfig AWS CloudFormation Resource (AWS::EKS::Nodegroup.UpdateConfig)
+// TODO @nikimanoledaki: "See" with link to AWS CF docs
+type Nodegroup_UpdateConfig struct {
+
+	// MaxUnavailable AWS CloudFormation Property
+	// Required: false
+	// TODO: add link to docs
+	MaxUnavailable *types.Value `json:"MaxUnavailable,omitempty"`
+
+	// MaxUnavailablePercentage AWS CloudFormation Property
+	// Required: false
+	// TODO: add link to docs
+	MaxUnavailablePercentage *types.Value `json:"MaxUnavailablePercentage,omitempty"`
+}


### PR DESCRIPTION
Related to the new `eksctl` feature about handling parallel upgrades for managed nodes: https://github.com/weaveworks/eksctl/issues/3613. 

This PR creates a `Nodegroup_UpdateConfig` struct that contains the fields `MaxUnavailable` and `MaxUnavailablePercentage`.