### PR TITLE
add ipv6cidrblock and ipv6pool to cloudformation

### DIFF
--- a/cloudformation/ec2/aws-ec2-vpccidrblock.go
+++ b/cloudformation/ec2/aws-ec2-vpccidrblock.go
@@ -24,6 +24,16 @@ type VPCCidrBlock struct {
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html#cfn-ec2-vpccidrblock-cidrblock
 	CidrBlock *types.Value `json:"CidrBlock,omitempty"`
 
+	// Ipv6CidrBlock AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html#cfn-ec2-vpccidrblock-ipv6cidrblock
+	Ipv6CidrBlock string `json:"Ipv6CidrBlock,omitempty"`
+
+	// Ipv6Pool AWS CloudFormation Property
+	// Required: false
+	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html#cfn-ec2-vpccidrblock-ipv6pool
+	Ipv6Pool string `json:"Ipv6Pool,omitempty"`
+
 	// VpcId AWS CloudFormation Property
 	// Required: true
 	// See: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html#cfn-ec2-vpccidrblock-vpcid


### PR DESCRIPTION
Taken from https://github.com/awslabs/goformation/blob/master/cloudformation/ec2/aws-ec2-vpccidrblock.go